### PR TITLE
fix: updated hex parsing to properly account for the double # error in 3-char long hexstrings

### DIFF
--- a/spectral.js
+++ b/spectral.js
@@ -659,7 +659,11 @@
    */
   const parse = (str) => {
     if (str[0] === '#') {
-      str = str.length === 4 ? str.replace(/./g, (m) => m + m).slice(1) : str.slice(1);
+      str = str.slice(1);
+      if (str.length === 3) {
+        str = str.replace(/./g, (m) => m + m)
+      }
+
       return [
         parseInt(str.substring(0, 2), 16),
         parseInt(str.substring(2, 4), 16),


### PR DESCRIPTION
Hi!

I was playing around with your repo the other day when I noticed that the parsing logic for 3-letter long Hex strings would clone the # character at the start but only dropping one of the 2 copies, essentially messing up the hex byte pairs, so I went ahead and created this PR fixing this!

```
import { Color } from "./spectral.js";

let red = new Color("#F00")

console.log(red.lRGB)
```

would output:

`[ NaN, 0.8713671191987973, 0 ]` 

Instead of 

`[ 1, 0, 0 ]`